### PR TITLE
independent remapping of reads and haplotype phase

### DIFF
--- a/mapping/filter_remapped_reads.py
+++ b/mapping/filter_remapped_reads.py
@@ -171,15 +171,19 @@ def write_reads(to_remap_bam, keep_bam, keep_reads, bad_reads, cigar_strings):
                 read.cigarstring in cigar_strings[read.qname][read.is_read2]
                 and len(cigar_strings[read.qname][read.is_read2]) == 1
             ):
-                # cache reads until you see their pair
-                # then, write both of them to file together
-                if read.qname in read_pair_cache:
-                    keep_bam.write(read_pair_cache[read.qname])
-                    del read_pair_cache[read.qname]
-                    keep_bam.write(read)
-                    keep_count += 2
+                if read.is_paired:
+                    # cache reads until you see their pair
+                    # then, write both of them to file together
+                    if read.qname in read_pair_cache:
+                        keep_bam.write(read_pair_cache[read.qname])
+                        del read_pair_cache[read.qname]
+                        keep_bam.write(read)
+                        keep_count += 2
+                    else:
+                        read_pair_cache[read.qname] = read
                 else:
-                    read_pair_cache[read.qname] = read
+                    keep_bam.write(read)
+                    keep_count += 1
             else:
                 discard_count += 1
         else:

--- a/mapping/filter_remapped_reads.py
+++ b/mapping/filter_remapped_reads.py
@@ -44,6 +44,22 @@ def parse_options():
     return parser.parse_args()
 
 
+class ReadStats:
+    """Track information about what the program is doing with reads"""
+    def __init__(self):
+        self.keep = 0
+        self.bad = 0
+        self.discard = 0
+
+        # reads that were discarded because they (or their pair) remapped with
+        # a different cigar string
+        self.cigar_discard = 0
+
+    def write(self):
+        sys.stderr.write("keep_reads: %d\n" % self.keep)
+        sys.stderr.write("bad_reads: %d\n" % self.bad)
+        sys.stderr.write("discard_reads: %d\n" % self.discard)
+        sys.stderr.write("\tof those, %d\n reads remapped with a different cigar" % self.cigar_discard)
 
 
 def filter_reads(remap_bam):
@@ -155,15 +171,13 @@ def filter_reads(remap_bam):
 def write_reads(to_remap_bam, keep_bam, keep_reads, bad_reads, cigar_strings):
     """writes reads but also checks cigar strings"""
 
-    keep_count = 0
-    bad_count = 0
-    discard_count = 0
+    stats = ReadStats()
 
     read_pair_cache = {}
 
     for read in to_remap_bam:
         if read.qname in bad_reads:
-            bad_count += 1
+            stats.bad += 1
         elif read.qname in keep_reads:
             # check that the cigar strings match up
             # and that all alternative versions of this read had the same CIGAR
@@ -178,22 +192,22 @@ def write_reads(to_remap_bam, keep_bam, keep_reads, bad_reads, cigar_strings):
                         keep_bam.write(read_pair_cache[read.qname])
                         del read_pair_cache[read.qname]
                         keep_bam.write(read)
-                        keep_count += 2
+                        stats.keep += 2
                     else:
                         read_pair_cache[read.qname] = read
                 else:
                     keep_bam.write(read)
-                    keep_count += 1
+                    stats.keep += 1
             else:
-                discard_count += 1
+                stats.discard += 1
+                stats.cigar_discard += 1
         else:
-            discard_count += 1
+            stats.discard += 1
     # any reads remaining in the cache have been discarded
-    discard_count += len(read_pair_cache)
+    stats.discard += len(read_pair_cache)
+    stats.cigar_discard += len(read_pair_cache)
 
-    sys.stderr.write("keep_reads: %d\n" % keep_count)
-    sys.stderr.write("bad_reads: %d\n" % bad_count)
-    sys.stderr.write("discard_reads: %d\n" % discard_count)
+    stats.write()
     
 
     

--- a/mapping/filter_remapped_reads.py
+++ b/mapping/filter_remapped_reads.py
@@ -58,8 +58,7 @@ class ReadStats:
     def write(self):
         sys.stderr.write("keep_reads: %d\n" % self.keep)
         sys.stderr.write("bad_reads: %d\n" % self.bad)
-        sys.stderr.write("discard_reads: %d\n" % self.discard)
-        sys.stderr.write("\tof those, %d\n reads remapped with a different cigar" % self.cigar_discard)
+        sys.stderr.write("discard_reads: {} (of which {} remapped with a different cigar)".format(self.discard, self.cigar_discard))
 
 
 def filter_reads(remap_bam):

--- a/mapping/filter_remapped_reads.py
+++ b/mapping/filter_remapped_reads.py
@@ -58,7 +58,7 @@ class ReadStats:
     def write(self):
         sys.stderr.write("keep_reads: %d\n" % self.keep)
         sys.stderr.write("bad_reads: %d\n" % self.bad)
-        sys.stderr.write("discard_reads: {} (of which {} remapped with a different cigar)".format(self.discard, self.cigar_discard))
+        sys.stderr.write("discard_reads: {} (of which {} remapped with a different cigar)\n".format(self.discard, self.cigar_discard))
 
 
 def filter_reads(remap_bam):

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -562,15 +562,13 @@ def generate_reads(read_seq, read_pos, ref_alleles, alt_alleles):
     of alleles (i.e. 2^n combinations where n is the number of snps overlapping
     the reads)
     """
-    # use a deque so that we can use the same object in memory after
-    # the nested for loop (rather than recreating a new list every time)
-    reads = deque([read_seq])
+    reads = [read_seq]
     # iterate through all snp locations
     for i in range(len(read_pos)):
         idx = read_pos[i]-1
         # for each read we've already created...
         for j in range(len(reads)):
-            read = reads.popleft()
+            read = reads[j]
             # create a new version of this read with both reference
             # and alternative versions of the allele at this index
             reads.append(
@@ -799,14 +797,12 @@ def read_pair_combos(old_reads, new_reads, max_seqs, snp_idx, snp_read_pos):
         unique_pairs - a set of tuples, each representing a unique pair of
                        new_reads
     """
-    # get the indices of the SNPs that are in both reads
-    shared_snp_idxs = set(snp_idx[0]).intersection(snp_idx[1])
     # get the indices of the shared SNPs in old_reads
     for i in range(len(snp_read_pos)):
-        # first, get the index of each snp_index in snp_idx
-        idx_idx = np.array([snp_idx[i].index(idx) for idx in shared_snp_idxs], dtype=int)
-        # now, use the indices in idx_idx to get the indices of the
-        # shared SNPs in the actual reads. note that we subtract by 1 to
+        # get the indices of the SNP indices that are in both reads
+        idx_idxs = np.nonzero(np.in1d(snp_idx[i], snp_idx[(i+1) % 2]))[0]
+        # now, use the indices in idx_idxs to get the relevant snp positions
+        snp_read_pos[i] = np.array(snp_read_pos[i], dtype=int)[idx_idxs]
         # convert positions to indices
         snp_read_pos[i] = np.array(snp_read_pos[i], dtype=int)[idx_idx] - 1
     # check: are there discordant alleles at the shared SNPs?

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -748,9 +748,10 @@ def group_reads_by_snps(reads, snp_read_pos):
 
 def read_pair_combos(old_reads, new_reads, max_seqs, snp_idx, snp_read_pos):
     """
-    collect all unique combinations of read pairs.
-    returns False before more than max_seqs pairs are created and
-    None when the original read pair has discordant alleles at shared SNPs
+    Collects all unique combinations of read pairs. Handles the possibility of
+    shared SNPs among the pairs (ie doesn't treat them as independent).
+    Returns False before more than max_seqs pairs are created or None
+    when the original read pair has discordant alleles at shared SNPs.
     Input:
         old_reads - a tuple of length 2, containing the pair of original reads
         new_reads - a list of two sets, each containing the reads generated
@@ -780,13 +781,14 @@ def read_pair_combos(old_reads, new_reads, max_seqs, snp_idx, snp_read_pos):
         != slice_read(old_reads[1], snp_read_pos[1])
     ):
         return None
-    # group reads by their shared SNPs
+    # group reads by the alleles they have at shared SNPs
     for i in range(len(new_reads)):
         new_reads[i] = group_reads_by_snps(
             new_reads[i], snp_read_pos[i]
         )
     unique_pairs = set()
-    # calculate the unique combinations of read pairs only among the same group
+    # calculate unique combinations of read pairs only among reads that
+    # have the same alleles at shared SNPs (ie if they're in the correct group)
     for group in range(len(new_reads[0])):
         for pair in product(new_reads[0][group], new_reads[1][group]):
             if len(unique_pairs) <= max_seqs:

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -802,9 +802,8 @@ def read_pair_combos(old_reads, new_reads, max_seqs, snp_idx, snp_read_pos):
         # get the indices of the SNP indices that are in both reads
         idx_idxs = np.nonzero(np.in1d(snp_idx[i], snp_idx[(i+1) % 2]))[0]
         # now, use the indices in idx_idxs to get the relevant snp positions
-        snp_read_pos[i] = np.array(snp_read_pos[i], dtype=int)[idx_idxs]
-        # convert positions to indices
-        snp_read_pos[i] = np.array(snp_read_pos[i], dtype=int)[idx_idx] - 1
+        # and convert positions to indices
+        snp_read_pos[i] = np.array(snp_read_pos[i], dtype=int)[idx_idxs] - 1
     # check: are there discordant alleles at the shared SNPs?
     # if so, discard these reads
     if (

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -522,27 +522,23 @@ def generate_reads(read_seq, read_pos, ref_alleles, alt_alleles):
     of alleles (i.e. 2^n combinations where n is the number of snps overlapping
     the reads)
     """
-    # use a deque so that we can use the same object in memory when we get to
-    # the nested while loop (rather than recreating a new list every time)
+    # use a deque so that we can use the same object in memory after
+    # the nested for loop (rather than recreating a new list every time)
     reads = deque([read_seq])
-    i = 0
     # iterate through all snp locations
-    while i != len(read_pos):
+    for i in range(len(read_pos)):
         idx = read_pos[i]-1
-        j = len(reads)
         # for each read we've already created...
-        while j > 0:
+        for j in range(len(reads)):
             read = reads.popleft()
-            # create a new version of this read with both reference...
+            # create a new version of this read with both reference
+            # and alternative versions of the allele at this index
             reads.append(
               read[:idx] + ref_alleles[i].decode("utf-8") + read[idx+1:]
             )
-            # and alternative versions of the allele at this index
             reads.append(
               read[:idx] + alt_alleles[i].decode("utf-8") + read[idx+1:]
             )
-            j -= 1
-        i += 1
     return set(reads)
 
 
@@ -757,8 +753,8 @@ def read_pair_combos(new_reads, max_seqs, snp_idx, snp_read_pos):
     returns False before more than max_seqs pairs are created
     """
     unique_pairs = set()
-    # get a list of the snps that are in both reads
-    shared_snp_idxs = list(set(snp_idx[0]) & set(snp_idx[1]))
+    # get the indices of the snps that are in both reads
+    shared_snp_idxs = set(snp_idx[0]).intersection(snp_idx[1])
     # get a grouping of the reads
     for i in range(len(new_reads)):
         new_reads[i] = group_reads_by_snps(

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -4,7 +4,6 @@ import gzip
 import argparse
 import numpy as np
 from itertools import product, groupby
-from collections import deque
 
 import pysam
 
@@ -527,15 +526,13 @@ def generate_reads(read_seq, read_pos, ref_alleles, alt_alleles):
     of alleles (i.e. 2^n combinations where n is the number of snps overlapping
     the reads)
     """
-    # use a deque so that we can use the same object in memory after
-    # the nested for loop (rather than recreating a new list every time)
-    reads = deque([read_seq])
+    reads = [read_seq]
     # iterate through all snp locations
     for i in range(len(read_pos)):
         idx = read_pos[i]-1
         # for each read we've already created...
         for j in range(len(reads)):
-            read = reads.popleft()
+            read = reads[j]
             # create a new version of this read with both reference
             # and alternative versions of the allele at this index
             reads.append(
@@ -764,14 +761,12 @@ def read_pair_combos(old_reads, new_reads, max_seqs, snp_idx, snp_read_pos):
         unique_pairs - a set of tuples, each representing a unique pair of
                        new_reads
     """
-    # get the indices of the SNPs that are in both reads
-    shared_snp_idxs = set(snp_idx[0]).intersection(snp_idx[1])
     # get the indices of the shared SNPs in old_reads
     for i in range(len(snp_read_pos)):
-        # first, get the index of each snp_index in snp_idx
-        idx_idx = np.array([snp_idx[i].index(idx) for idx in shared_snp_idxs], dtype=int)
-        # now, use the indices in idx_idx to get the relavent snp positions
-        snp_read_pos[i] = np.array(snp_read_pos[i], dtype=int)[idx_idx]
+        # get the indices of the SNP indices that are in both reads
+        idx_idxs = np.nonzero(np.in1d(snp_idx[i], snp_idx[(i+1) % 2]))[0]
+        # now, use the indices in idx_idxs to get the relevant snp positions
+        snp_read_pos[i] = np.array(snp_read_pos[i], dtype=int)[idx_idxs]
         # convert positions to indices
         snp_read_pos[i] = np.subtract(snp_read_pos[i], 1)
     # check: are there discordant alleles at the shared SNPs?

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -4,7 +4,6 @@ import gzip
 import argparse
 import numpy as np
 from itertools import product, groupby
-from collections import deque, defaultdict
 
 import pysam
 

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -718,6 +718,22 @@ def filter_reads(files, max_seqs=MAX_SEQS_DEFAULT, max_snps=MAX_SNPS_DEFAULT,
 
 def read_pair_combinations(new_reads, max_seqs, snp_idx, snp_pos):
     """collect all unique combinations of read pairs"""
+
+    # get a list of the snps that are in both reads
+    shared_snp_idxs = list(set(snp_idx[0]) & set(snp_idx[1]))
+    # find the index of each snp_index in snp_idx
+    idx_idxs = (
+        np.array([snp_idx[0].index(idx) for idx in shared_snp_idxs], dtype=int),
+        np.array([snp_idx[1].index(idx) for idx in shared_snp_idxs], dtype=int)
+    )
+    # use idx_idxs to get the read positions of each snp that appears in
+    # both reads
+    snp_pos = np.column_stack((
+        np.array(snp_pos[0], dtype=int)[idx_idxs[0]],
+        np.array(snp_pos[1], dtype=int)[idx_idxs[1]],
+    ))
+    print(snp_pos)
+
     unique_pairs = set([])
     n_unique_pairs = 0
     for new_read1 in new_reads[0]:
@@ -786,6 +802,8 @@ def process_paired_read(read1, read2, read_stats, files,
             new_reads.append(read_seqs)
         else:
             # no SNPs or indels overlap this read
+            pair_snp_idx.append([])
+            pair_snp_pos.append([])
             new_reads.append([])
 
     if len(new_reads[0]) == 0 and len(new_reads[1]) == 0:

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -430,6 +430,7 @@ def count_ref_alt_matches(read, read_stats, snp_tab, snp_idx, read_pos):
 def get_unique_haplotypes(haplotypes, phasing, snp_idx):
     """
     returns list of vectors of unique haplotypes for this set of SNPs
+    all possible combinations of ref/alt are calculated at unphased sites
     """
     haps = haplotypes[snp_idx,:].T
     
@@ -439,7 +440,7 @@ def get_unique_haplotypes(haplotypes, phasing, snp_idx):
         phasing = np.logical_not(phasing[snp_idx, :].T.astype(bool))
     else:
         # assume all SNPs are unphased
-        phasing = np.full((haps.shape[0]/2, haps.shape[1]), True)
+        phasing = np.full((int(haps.shape[0]/2), haps.shape[1]), True)
 
     # if a haplotype has unphased SNPs, generate all possible allelic
     # combinations and add each combination as a new haplotype
@@ -472,7 +473,7 @@ def get_unique_haplotypes(haplotypes, phasing, snp_idx):
     h = np.ascontiguousarray(haps).view(np.dtype((np.void, haps.dtype.itemsize * haps.shape[1])))
 
     # get index of unique columns
-    _, idx, inverse_idx = np.unique(h, return_index=True, return_inverse=True)
+    _, idx = np.unique(h, return_index=True)
 
 
     return haps[idx,:]

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -844,9 +844,7 @@ def process_paired_read(read1, read2, read_stats, files,
             return
 
         # remove original read pair, if present
-        orig_pair = (read1.query_sequence, read2.query_sequence)
-        if orig_pair in unique_pairs:
-            unique_pairs.remove(orig_pair)
+        unique_pairs.discard((read1.query_sequence, read2.query_sequence))
             
         # write read pair to fastqs for remapping
         write_pair_fastq(files.fastq1, files.fastq2, read1, read2,

--- a/mapping/snptable.py
+++ b/mapping/snptable.py
@@ -39,6 +39,7 @@ class SNPTable(object):
         self.snp_allele1 = np.array([], dtype="|S10")
         self.snp_allele2 = np.array([], dtype="|S10")
         self.haplotypes = None
+        self.phase = None
         self.n_snp = 0
         self.samples = []
         
@@ -49,6 +50,7 @@ class SNPTable(object):
         """read in SNPs and indels from HDF5 input files"""
 
         node_name = "/%s" % chrom_name
+        phase_node_name = "/phase_%s" % chrom_name
         
         if node_name not in snp_tab_h5:
             sys.stderr.write("WARNING: chromosome %s is not "
@@ -70,6 +72,8 @@ class SNPTable(object):
             self.n_snp = self.snp_pos.shape[0]
             self.samples = self.get_h5_samples(hap_h5, chrom_name)
             self.haplotypes = hap_h5.get_node(node_name)
+            if phase_node_name in hap_h5:
+                self.phase = hap_h5.get_node(phase_node_name)
             
             if samples:
                 # reduce set of SNPs and indels to ones that are
@@ -91,6 +95,8 @@ class SNPTable(object):
                 hap_idx[0::2] = samp_idx*2
                 hap_idx[1::2] = samp_idx*2 + 1
                 haps = self.haplotypes[:, hap_idx]
+                if self.phase:
+                    phase = self.phase[:, samp_idx]
 
                 # count number of ref and non-ref alleles,
                 # ignoring undefined (-1s)
@@ -113,6 +119,8 @@ class SNPTable(object):
                 self.samples = [x[0] for x in sorted_samps]
                 
                 self.haplotypes = haps[is_polymorphic,]
+                if self.phase:
+                    self.phase = phase[is_polymorphic,]
                 self.snp_pos = self.snp_pos[is_polymorphic]
                 self.snp_allele1 = self.snp_allele1[is_polymorphic]
                 self.snp_allele2 = self.snp_allele2[is_polymorphic]

--- a/mapping/test_find_intersecting_snps.py
+++ b/mapping/test_find_intersecting_snps.py
@@ -3297,14 +3297,14 @@ class TestOverlappingPEReads:
         #
         with gzip.open(test_data.fastq1_remap_filename, "rt") as f:
             lines = [x.strip() for x in f.readlines()]
-        assert len(lines) == 8
+        assert(len(lines) == 8)
 
         l = list(test_data.read1_seqs[0])
         # last base of first read should be changed from A to C
         l[13] = 'C'
         new_seq = "".join(l)
-        assert lines[1] == new_seq
-        assert lines[3] == test_data.read1_quals[0]
+        assert(lines[1] == new_seq)
+        assert(lines[3] == test_data.read1_quals[0])
 
         l = list(test_data.read1_seqs[1])
         # second to last base of second read should be changed from T to G
@@ -3318,21 +3318,21 @@ class TestOverlappingPEReads:
         #
         with gzip.open(test_data.fastq2_remap_filename, "rt") as f:
             lines = [x.strip() for x in f.readlines()]
-        assert len(lines) == 8
+        assert(len(lines) == 8)
 
-        l = list(test_data.read1_seqs[0])
+        l = list(test_data.read2_seqs[0])
         # second to last base of first read should be changed from T to G (since G is the complement of C)
         l[12] = 'G'
         new_seq = "".join(l)
-        assert lines[1] == new_seq
-        assert lines[3] == test_data.read1_quals[0]
+        assert(lines[1] == new_seq)
+        assert(lines[3] == test_data.read2_quals[0])
 
-        l = list(test_data.read1_seqs[1])
+        l = list(test_data.read2_seqs[1])
         # second to last base of second read should be changed from A to C (since C is the complement of G)
         l[12] = 'C'
         new_seq = "".join(l)
         assert(lines[5] == new_seq)
-        assert(lines[7] == test_data.read1_quals[1])
+        assert(lines[7] == test_data.read2_quals[1])
 
         #
         # Verify to.remap bam is the same as the input bam file.

--- a/mapping/test_find_intersecting_snps.py
+++ b/mapping/test_find_intersecting_snps.py
@@ -1336,7 +1336,7 @@ class TestPairedEnd:
         # read2[0]                      AACACAACAAAGAA
         # read2[1]                      AACACAACAAAGAA
         # POS           123456789012345678901234567890
-        
+
         snp_list = [['test_chrom', 18, "A", "C"]]
         
         test_data = Data(genome_seqs=genome_seq,
@@ -2603,7 +2603,7 @@ class TestHaplotypesSingleEnd:
         assert len(lines) == 1
         assert lines[0] == ''
 
-        # test_data.cleanup()
+        test_data.cleanup()
 
 
 
@@ -2774,7 +2774,7 @@ class TestHaplotypesPairedEnd:
         assert lines2[1] == test_data.read2_seqs[0]
         assert lines2[3] == test_data.read2_quals[0]
 
-        # test_data.cleanup()
+        test_data.cleanup()
 
 
 class TestFiltering:

--- a/mapping/test_find_intersecting_snps.py
+++ b/mapping/test_find_intersecting_snps.py
@@ -3254,8 +3254,8 @@ class TestOverlappingPEReads:
 
         read1_seqs = ["AACGAAAAGGAGAA",
                       "TTTATTTTTTATTT"]
-        read2_seqs = ["TTTTAAATTTTTTT",
-                      "ACAACACAAAAAAA"]
+        read2_seqs = ["TTTTAAATTTTTTT",  # AAAAAAATTTAAAA
+                      "ACAACACAAAAAAA"]  # TTTTTTTGTGTTGT
 
         read1_quals = ["B" * len(read1_seqs[0]),
                        "C" * len(read1_seqs[1])]
@@ -3264,12 +3264,12 @@ class TestOverlappingPEReads:
 
         # POS           123456789012345678901234567890
         # read1[0]          AACGAAAAGGAGAA
-        # read2[0]                      TTTTAAATTTTTTT
+        # read2[0]                      AAAAAAATTTAAAA
         # SNP                            ^
         genome_seq =  ["AAAAAACGAAAAGGAGAAAAAAATTTAAAA\n"
                        "TTTATTTTTTATTTTTTTGTGTTGTTTCTT"]
         # read1[1]      TTTATTTTTTATTT
-        # read2[1]                 ACAACACAAAAAAA
+        # read2[1]                 TTTTTTTGTGTTGT
         # SNP                       ^
         # POS           123456789012345678901234567890
 
@@ -3359,8 +3359,8 @@ class TestOverlappingPEReads:
 
         read1_seqs = ["AACGAAAAGGAGAA",
                       "TTTATTTTTTATTT"]
-        read2_seqs = ["TTTTAAATTTTTTT",
-                      "ACAACACAAAAAAA"]
+        read2_seqs = ["TTTTAAATTTTTTT",  # AAAAAAATTTAAAA
+                      "ACAACACAAAAAAA"]  # TTTTTTTGTGTTGT
 
         read1_quals = ["B" * len(read1_seqs[0]),
                        "C" * len(read1_seqs[1])]
@@ -3369,13 +3369,13 @@ class TestOverlappingPEReads:
 
         # POS           123456789012345678901234567890
         # read1[0]          AACGAAAAGGAGAA
-        # read2[0]                      TTTTAAATTTTTTT
-        # SNP                           ^^
+        # read2[0]                      AAAAAAATTTAAAA
+        # SNPs                          ^^
         genome_seq =  ["AAAAAACGAAAAGGAGAAAAAAATTTAAAA\n"
                        "TTTATTTTTTATTTTTTTGTGTTGTTTCTT"]
         # read1[1]      TTTATTTTTTATTT
-        # read2[1]                 ACAACACAAAAAAA
-        # SNP                      ^^
+        # read2[1]                 TTTTTTTGTGTTGT
+        # SNPs                     ^^
         # POS           123456789012345678901234567890
 
         snp_list = [['test_chrom', 17, "A", "T"],
@@ -3404,13 +3404,13 @@ class TestOverlappingPEReads:
         #
         with gzip.open(test_data.fastq1_remap_filename, "rt") as f:
             seqs1 = [x.strip() for x in f.readlines()][1::4]
-            # there are two pairs of reads and two snps (each with two alleles),
+            # there are two pairs of reads and two snps (each with two alleles)
             # leading to 2^2 combinations of alleles. however, one of those
             # combinations is the original pair (hence why we subtract by one)
             assert(len(set(seqs1)) == 2*(2**2-1))
         with gzip.open(test_data.fastq2_remap_filename, "rt") as f:
             seqs2 = [x.strip() for x in f.readlines()][1::4]
-            # there are two pairs of reads and two snps (each with two alleles),
+            # there are two pairs of reads and two snps (each with two alleles)
             # leading to 2^2 combinations of alleles. however, one of those
             # combinations is the original pair (hence why we subtract by one)
             assert(len(set(seqs2)) == 2*(2**2-1))
@@ -3419,33 +3419,45 @@ class TestOverlappingPEReads:
         expect_reads1 = [
             # only last base of first read should be changed from A to C
             "AACGAAAAGGAGAC",
-            # only second to last base of first read should be changed from A to T
+            # only second to last base of first read should be changed from A
+            # to T
             "AACGAAAAGGAGTA",
             # last base of first read should be changed from A to C
-            # AND second to last base of first read should be changed from A to T
+            # AND second to last base of first read should be changed from A
+            # to T
             "AACGAAAAGGAGTC",
             # second to last base of second read should be changed from T to G
             "TTTATTTTTTATGT",
-            # only third to last base of second read should be changed from T to A
+            # only third to last base of second read should be changed from T
+            # to A
             "TTTATTTTTTAATT",
             # second to last base of second read should be changed from T to G
-            # AND third to last base of second read should be changed from T to A
+            # AND third to last base of second read should be changed from T
+            # to A
             "TTTATTTTTTAAGT"
         ]
         expect_reads2 = [
-            # only second to last base of first read should be changed from T to G
+            # only second to last base of first read should be changed from T
+            # to G (since it is the complement of C)
             "TTTTAAATTTTTGT",
-            # only last base of first read should be changed from T to A
+            # only last base of first read should be changed from T to A (since
+            # it is the complement of T)
             "TTTTAAATTTTTTA",
-            # last base of first read should be changed from T to A
-            # AND second to last base of first read should be changed from T to G
+            # last base of first read should be changed from T to A (since it
+            # is the complement of T)
+            # AND second to last base of first read should be changed from T
+            # to G (since it is the complement of C)
             "TTTTAAATTTTTGA",
             # second to last base of second read should be changed from A to C
+            # (since it is the complement of G)
             "ACAACACAAAAACA",
-            # last base of second read should be changed from A to T
+            # last base of second read should be changed from A to T (since it
+            # is the complement of C)
             "ACAACACAAAAAAT",
-            # last base of second read should be changed from A to T
-            # AND second to last base of second read should be changed from A to C
+            # last base of second read should be changed from A to T (since it
+            # is the complement of A)
+            # AND second to last base of second read should be changed from A
+            # to C (since it is the complement of G)
             "ACAACACAAAAACT"
         ]
         expect_pairs = list(zip(expect_reads1, expect_reads2))
@@ -3479,15 +3491,15 @@ class TestOverlappingPEReads:
         test_data = Data()
 
         read1_seqs = ["AACGAAAAGGAGAA"]
-        read2_seqs = ["TTTTAAATTTTTTT"]
+        read2_seqs = ["TTTTAAATTTTTTT"]  # AAAAAAATTTAAAA
 
         read1_quals = ["B" * len(read1_seqs[0])]
         read2_quals = ["D" * len(read2_seqs[0])]
 
         # POS           123456789012345678901234567890
         # read1[0]          AACGAAAAGGAGAA
-        # read2[0]                      TTTTAAATTTTTTT
-        # SNP                    ^       ^^
+        # read2[0]                      AAAAAAATTTAAAA
+        # SNPs                   ^       ^^
         genome_seq =  ["AAAAAACGAAAAGGAGAAAAAAATTTAAAA\n"
                        "TTTATTTTTTATTTTTTTGTGTTGTTTCTT"]
 

--- a/snp2h5/Makefile
+++ b/snp2h5/Makefile
@@ -24,4 +24,4 @@ fasta2h5: fasta2h5.o $(objects)
 all: snp2h5 fasta2h5 $(objects)
 
 clean:
-	rm -f $(objects) snp2h5 fasta2h5
+	rm -f $(objects) snp2h5.o fasta2h5.o snp2h5 fasta2h5

--- a/snp2h5/snp2h5.c
+++ b/snp2h5/snp2h5.c
@@ -1055,6 +1055,7 @@ void parse_vcf(Arguments *args, Chromosome *all_chroms, int n_chrom,
   long i, j;
   float *geno_probs;
   char *haplotypes;
+  char *haplotypes_phase;
   long *snp_index;
   SNP snp;
   hsize_t row;
@@ -1062,6 +1063,10 @@ void parse_vcf(Arguments *args, Chromosome *all_chroms, int n_chrom,
   Chromosome *chrom;
   SampleTab *samp_tab;
   char **vcf_by_chrom;
+
+  /* create matrix to hold phase info */
+  H5MatrixInfo haplotype_phase_info;
+  haplotype_phase_info.h5file = haplotype_info->h5file;
   
   vcf = vcf_info_new();
 
@@ -1137,6 +1142,12 @@ void parse_vcf(Arguments *args, Chromosome *all_chroms, int n_chrom,
 	samp_tab = sample_tab_from_names(haplotype_info->h5file, chrom->name,
 					 vcf->sample_names, vcf->n_sample);
 	sample_tab_free(samp_tab);
+
+  /* initialize the phase matrix */
+  haplotypes_phase = my_malloc(vcf->n_sample * sizeof(char));
+  init_h5matrix(&haplotype_phase_info, haplotype_info->n_row,
+          vcf->n_sample,
+          HAPLOTYPE_DATATYPE, util_str_concat("phase_", chrom->name, NULL));
       }
     } else {
       haplotypes = NULL;
@@ -1168,13 +1179,14 @@ void parse_vcf(Arguments *args, Chromosome *all_chroms, int n_chrom,
     int done = FALSE;
     
     while(!done && vcf_read_line(gzf, vcf, &snp,
-				 geno_probs, haplotypes) != -1) {
+				 geno_probs, haplotypes, haplotypes_phase) != -1) {
       
       if(geno_probs) {
 	write_h5matrix_row(gprob_info, row, geno_probs);
       }
       if(haplotypes) {
 	write_h5matrix_row(haplotype_info, row, haplotypes);
+  write_h5matrix_row(&haplotype_phase_info, row, haplotypes_phase);
       }
 
       /*  set snp_index element at this chromosome position
@@ -1226,6 +1238,10 @@ void parse_vcf(Arguments *args, Chromosome *all_chroms, int n_chrom,
     if(haplotypes) {
       my_free(haplotypes);
       close_h5matrix(haplotype_info);
+    }
+    if(haplotypes_phase) {
+      my_free(haplotypes_phase);
+      close_h5matrix(&haplotype_phase_info);
     }
     if(snp_index) {
       my_free(snp_index);

--- a/snp2h5/vcf.h
+++ b/snp2h5/vcf.h
@@ -51,7 +51,7 @@ void vcf_read_header(gzFile vcf_fh, VCFInfo *vcf_info);
 
 int vcf_read_line(gzFile vcf_fh, VCFInfo *vcf_info, SNP *snp,
 		  float *geno_probs,
-		  char *haplotypes);
+		  char *haplotypes, char *haplotypes_phase);
 
 
 #endif


### PR DESCRIPTION
This PR introduces two new features to `find_intersecting_snps.py`. The code for both features makes every effort to be both memory and speed efficient and uses `numpy` whenever possible.

### Fixing Independent Remapping of Reads
When both reads from a read pair overlap a single variant, the reads that are generated for remapping should not be independent (i.e. if read1 has alternate allele, so should read2). In other words, generated reads should only be paired with each other if they have the same alleles at shared SNPs.

`find_intersecting_snps.py` was altered to support this behavior. A new function, `read_pair_combos()` computes all unique combinations of generated read pairs among reads that have the same alleles at shared SNPs. It uses another new function, `group_reads_by_snps()` to group a set of reads by whether they have the same alleles at shared SNPs.

Among 20 GTEX adrenal samples, this fix to the code resulted in on average 12% (std: 1.6%) more reads being kept by the end of the WASP pipeline.

Tests were written to ensure correct behavior.
1. `test_overlap_paired_two_reads_one_snp()` tests two pairs of reads, each with both pairs sharing a single SNP
2. `test_overlap_paired_two_reads_two_snps()` is similar but has both pairs overlapping two SNPs instead of one
2. `test_overlap_paired_one_read_one_snp_one_snp()` tests a single paired read, where both pairs share a SNP and overlap one other unshared SNP
3. `test_overlap_paired_one_read_one_discordant_snp()` tests a single paired read, where both pairs share a single SNP but have different alleles at that SNP. Reads should be discarded in this case.

Also, `generate_reads()` was rewritten to avoid recursion. Although less elegant, this likely helps it use less memory.


### Considering Haplotype Phase
`snp2h5` doesn't consider haplotype phase when generating `haplotypes.h5`. However, `find_intersecting_snps.py` assumes all haplotypes are phased when it uses `haplotype.h5`.

`snp2h5` was altered to add a new phase `carray` to `haplotype.h5` containing phase information from the VCF. The structure of the `carray` is similar to that of the haplotypes themselves: there is a row for each SNP but only a single column for each individual. A value of 0 indicates an unphased genotype and a value of 1 indicates the genotype is phased.

`find_intersecting_snps.py` will now use the phase information from `haplotype.h5` to calculate new haplotypes with all possible allelic combinations at unphased sites, resulting in more reads being generated for remapping. If phase information is not provided in `haplotype.h5`, all sites will be assumed unphased.


Among the same 20 GTEX adrenal samples, assuming all sites unphased resulted in on average 0.2% (std: 0.08%) less reads being kept by the end of the WASP pipeline.

The new behavior of `snp2h5` was verified manually, and `test_find_intersecting_snps.py` was altered to ensure new code in `find_intersecting_snps.py` worked correctly.
1. `test_haplotypes_phase_single_one_read_two_snps()` tests that marking a certain genotype as unphased causes another read to be generated for remapping containing an additional haplotype configuration.
2. All prior tests in `test_find_intersecting_snps.py` were rewritten so that their haplotypes would be assumed phased.